### PR TITLE
fix: web server and default relays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ lru = "0.12"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "limit", "timeout"] }
 tower_governor = "0.4"
+forwarded-header-value = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
 anyhow = "1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build stage
-FROM rust:1.85-slim-bookworm AS builder
+# Transitive crates (e.g. icu_*) require rustc ≥ 1.86; keep in sync with Cargo.lock / deps.
+FROM rust:1.86-slim-bookworm AS builder
 
 LABEL org.opencontainers.image.source="https://github.com/nostr-wot/nostr-wot-oracle"
 LABEL org.opencontainers.image.description="Pairwise distance queries for Nostr Web of Trust"
@@ -34,8 +35,9 @@ FROM debian:bookworm-slim
 WORKDIR /app
 
 # Install runtime dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the binary from builder

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,28 @@
+# Runtime image from a pre-built Linux ELF at target/release/wot-oracle (see docker-compose.release.yml).
+#
+# Not usable with Windows-only `cargo build --release` (that produces wot-oracle.exe). Use the
+# default docker-compose.yml (Dockerfile) instead, or build the Linux binary in WSL / cross-compile.
+
+FROM debian:bookworm-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY target/release/wot-oracle /app/wot-oracle
+
+RUN chmod +x /app/wot-oracle && mkdir -p /app/data
+
+ENV DB_PATH=/app/data/wot.db
+ENV HTTP_PORT=8080
+ENV RUST_LOG=info
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:8080/health || exit 1
+
+CMD ["/app/wot-oracle"]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cargo build --release
 ./target/release/wot-oracle
 
 # Or with custom relays
-RELAYS=wss://relay.mappingbitcoin.com,wss://relay.damus.io,wss://nos.lol ./target/release/wot-oracle
+RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.primal.net/,wss://relay.mostr.pub ./target/release/wot-oracle
 ```
 
 ## API Usage

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -1,10 +1,18 @@
-version: '3.8'
+# Image from an existing Linux release binary at target/release/wot-oracle (no Rust compile in Docker).
+#
+# Windows: native `cargo build --release` produces wot-oracle.exe — that cannot be copied into
+# this Linux image. Build the ELF first, e.g. in WSL in this repo: `cargo build --release`, or
+# cross-compile: `cargo build --release --target x86_64-unknown-linux-gnu` and copy the artifact
+# to target/release/wot-oracle.
+#
+#   docker compose -f docker-compose.release.yml build
 
 services:
   nostr-wot-oracle:
-    image: ghcr.io/nostr-wot/nostr-wot-oracle:0.2.1
-    # Or build from source:
-    # build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.release
+    image: nostr-wot-oracle:local
     container_name: nostr-wot-oracle
     restart: unless-stopped
     ports:

--- a/docs/DVM.md
+++ b/docs/DVM.md
@@ -249,7 +249,7 @@ The DVM connects to the relays specified in the `RELAYS` environment variable. F
 
 Example configuration:
 ```bash
-RELAYS=wss://relay.mappingbitcoin.com,wss://relay.damus.io,wss://nos.lol,wss://relay.nostr.band
+RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.primal.net/,wss://relay.mostr.pub/
 ```
 
 ---

--- a/docs/SELF-HOST.md
+++ b/docs/SELF-HOST.md
@@ -29,7 +29,7 @@ docker run -d \
   --name wot-oracle \
   -p 8080:8080 \
   -v wot-data:/app/data \
-  -e RELAYS=wss://relay.mappingbitcoin.com,wss://relay.damus.io,wss://nos.lol,wss://relay.nostr.band \
+  -e RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.primal.net/,wss://relay.mostr.pub/ \
   -e CACHE_SIZE=20000 \
   -e RUST_LOG=debug \
   ghcr.io/nostr-wot/nostr-wot-oracle:0.2.1
@@ -64,7 +64,7 @@ Edit `.env` or pass environment variables to docker-compose:
 
 ```bash
 # .env file
-RELAYS=wss://relay.mappingbitcoin.com,wss://relay.damus.io,wss://nos.lol,wss://relay.nostr.band
+RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.primal.net/,wss://relay.mostr.pub/
 HTTP_PORT=8080
 RATE_LIMIT_PER_MINUTE=100
 CACHE_SIZE=10000
@@ -106,7 +106,7 @@ services:
     volumes:
       - nostr-wot-data:/app/data
     environment:
-      - RELAYS=${RELAYS:-wss://relay.mappingbitcoin.com,wss://relay.damus.io,wss://nos.lol,wss://relay.nostr.band}
+      - RELAYS=${RELAYS:-wss://relay.damus.io,wss://nos.lol,wss://relay.primal.net/,wss://relay.mostr.pub/}
       - HTTP_PORT=8080
       - DB_PATH=/app/data/wot.db
       - DVM_ENABLED=${DVM_ENABLED:-false}

--- a/docs/SYNC.md
+++ b/docs/SYNC.md
@@ -442,7 +442,7 @@ Need events from user X
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `RELAYS` | `wss://relay.damus.io,wss://nos.lol,wss://relay.nostr.band` | Seed relays for initial connections |
+| `RELAYS` | `wss://relay.damus.io,wss://nos.lol,wss://relay.primal.net/,wss://relay.mostr.pub/` | Seed relays for initial connections |
 
 ### Proposed Additions
 

--- a/src/api/governor_key.rs
+++ b/src/api/governor_key.rs
@@ -1,0 +1,66 @@
+//! Rate-limit key extraction using this crate's `axum` dependency.
+//!
+//! `tower_governor::SmartIpKeyExtractor` resolves `ConnectInfo<SocketAddr>` via its own optional
+//! `axum` dependency. If Cargo resolves two `axum` versions, extension `TypeId`s differ and every
+//! request fails with `GovernorError::UnableToExtractKey` (HTTP 500, body "Unable To Extract Key!").
+
+use axum::extract::ConnectInfo;
+use axum::http::{header::FORWARDED, HeaderMap, Request};
+use forwarded_header_value::{ForwardedHeaderValue, Identifier};
+use std::net::{IpAddr, SocketAddr};
+use tower_governor::key_extractor::KeyExtractor;
+use tower_governor::GovernorError;
+
+const X_REAL_IP: &str = "x-real-ip";
+const X_FORWARDED_FOR: &str = "x-forwarded-for";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OracleSmartIpKeyExtractor;
+
+impl KeyExtractor for OracleSmartIpKeyExtractor {
+    type Key = IpAddr;
+
+    fn extract<T>(&self, req: &Request<T>) -> Result<Self::Key, GovernorError> {
+        let headers = req.headers();
+        maybe_x_forwarded_for(headers)
+            .or_else(|| maybe_x_real_ip(headers))
+            .or_else(|| maybe_forwarded(headers))
+            .or_else(|| {
+                req.extensions()
+                    .get::<ConnectInfo<SocketAddr>>()
+                    .map(|ci| ci.ip())
+            })
+            .ok_or(GovernorError::UnableToExtractKey)
+    }
+}
+
+fn maybe_x_forwarded_for(headers: &HeaderMap) -> Option<IpAddr> {
+    headers
+        .get(X_FORWARDED_FOR)
+        .and_then(|hv| hv.to_str().ok())
+        .and_then(|s| s.split(',').find_map(|s| s.trim().parse::<IpAddr>().ok()))
+}
+
+fn maybe_x_real_ip(headers: &HeaderMap) -> Option<IpAddr> {
+    headers
+        .get(X_REAL_IP)
+        .and_then(|hv| hv.to_str().ok())
+        .and_then(|s| s.parse::<IpAddr>().ok())
+}
+
+fn maybe_forwarded(headers: &HeaderMap) -> Option<IpAddr> {
+    headers.get_all(FORWARDED).iter().find_map(|hv| {
+        hv.to_str()
+            .ok()
+            .and_then(|s| ForwardedHeaderValue::from_forwarded(s).ok())
+            .and_then(|f| {
+                f.iter()
+                    .filter_map(|fs| fs.forwarded_for.as_ref())
+                    .find_map(|ff| match ff {
+                        Identifier::SocketAddr(a) => Some(a.ip()),
+                        Identifier::IpAddr(ip) => Some(*ip),
+                        _ => None,
+                    })
+            })
+    })
+}

--- a/src/api/http.rs
+++ b/src/api/http.rs
@@ -10,7 +10,9 @@ use std::sync::Arc;
 use std::net::SocketAddr;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::limit::RequestBodyLimitLayer;
-use tower_governor::{GovernorLayer, governor::GovernorConfigBuilder, key_extractor::SmartIpKeyExtractor};
+use tower_governor::{GovernorLayer, governor::GovernorConfigBuilder};
+
+use super::governor_key::OracleSmartIpKeyExtractor;
 use tracing::{debug, info};
 
 use crate::cache::{CacheKey, CacheStats, QueryCache};
@@ -431,7 +433,7 @@ pub fn create_router(state: AppState, rate_limit_per_minute: u32) -> Router {
     let governor_conf = GovernorConfigBuilder::default()
         .per_second(per_second as u64)
         .burst_size(burst_size)
-        .key_extractor(SmartIpKeyExtractor)
+        .key_extractor(OracleSmartIpKeyExtractor)
         .finish()
         .expect("Invalid rate limit configuration");
 
@@ -475,7 +477,7 @@ mod tests {
     use axum::http::Request;
     use tower::ServiceExt;
 
-    /// Test router without rate limiting (SmartIpKeyExtractor fails in tests)
+    /// Test router without rate limiting (governor needs `ConnectInfo` from `serve` in real runs)
     fn create_test_router(state: AppState) -> Router {
         let cors = CorsLayer::new()
             .allow_origin(Any)

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,4 @@
+pub mod governor_key;
 pub mod http;
 pub mod dvm;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,7 @@ pub struct Config {
 impl Config {
     pub fn from_env() -> Self {
         let relays = env::var("RELAYS")
-            .unwrap_or_else(|_| "wss://relay.damus.io,wss://nos.lol,wss://relay.nostr.band".into())
+            .unwrap_or_else(|_| "wss://relay.damus.io,wss://nos.lol,wss://relay.primal.net/,wss://relay.mostr.pub/".into())
             .split(',')
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())


### PR DESCRIPTION
The 0.2.0 web server was not working on docker or locally. No 0.2.1 was tagged on you github project.
Relay server connection was fine, and the oracle download event just fine, but no https api response.
Make the AI apply some fixes and it runs fine now. 
Test it on:
https://wot-oracle.trust.dance

Cheers.
